### PR TITLE
feat: make carousel viewport visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,8 +145,8 @@
     }
     .carousel[aria-roledescription="carousel"] { outline: none; }
     .carousel-viewport {
-      overflow-x: auto;
-      overflow-y: visible;
+      overflow: visible;
+      overflow-x: visible;
       -webkit-overflow-scrolling: touch;
       overscroll-behavior-x: contain;
       scroll-snap-type: x mandatory;


### PR DESCRIPTION
## Summary
- allow carousel viewport overflow to be visible, including x-axis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac70fdf05c8325814e390947b1b482